### PR TITLE
Simplify the ``LastUpdatedOrderedDict`` example recipe

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -1141,7 +1141,7 @@ original insertion position is changed and moved to the end::
 
         def __setitem__(self, key, value):
             super().__setitem__(key, value)
-            super().move_to_end(key)
+            self.move_to_end(key)
 
 An :class:`OrderedDict` would also be useful for implementing
 variants of :func:`functools.lru_cache`::


### PR DESCRIPTION
This example seems to use `super()` unnecessarily. I didn't bother to create a bpo issue number because it seems a trivial docs change to me, but let me know if it's required.
Cheers,
Wim
